### PR TITLE
Optimizations

### DIFF
--- a/NFAI.Core/AbstractComputeCollection.cs
+++ b/NFAI.Core/AbstractComputeCollection.cs
@@ -33,13 +33,13 @@ public abstract class AbstractComputeCollection
         }
     }
 
-    protected async IAsyncEnumerable<byte[]> GetDataRaw()
+    protected IEnumerable<byte[]> GetDataRaw()
     {
         DataStream.Seek(offset, SeekOrigin.Begin);
         const int batchSizeInBytes = 1024 * 1024 * 10; // 100MB batch size, adjust as needed
         int itemsPerBatch = batchSizeInBytes;
         if (itemsPerBatch < 1) itemsPerBatch = 1;
-        
+
         var current = 0ul;
         var total = Length * TypeSize;
         // Read the entire batch
@@ -49,7 +49,7 @@ public abstract class AbstractComputeCollection
             // Calculate remaining items and adjust batch size if needed
             var itemsToRead = Math.Min(itemsPerBatch, (int)(total - current));
             var batchBuffer = new byte[itemsToRead];
-            
+
             try
             {
                 DataStream.ReadExactly(batchBuffer, 0, itemsToRead);
@@ -61,7 +61,7 @@ public abstract class AbstractComputeCollection
             current += (ulong)itemsToRead;
             if (TypeSize != 2)
             {
-                yield return [..batchBuffer];
+                yield return [.. batchBuffer];
             }
             else
             {
@@ -73,7 +73,7 @@ public abstract class AbstractComputeCollection
                     var bytes = BitConverter.GetBytes(f);
                     Array.Copy(bytes, 0, newBatchBuffer, j * 4, bytes.Length); // Copy float bytes to newBatchBuffer
                 }
-                yield return [..newBatchBuffer];
+                yield return [.. newBatchBuffer];
             }
         }
     }

--- a/NFAI.Core/ComputeCollection.cs
+++ b/NFAI.Core/ComputeCollection.cs
@@ -36,7 +36,7 @@ public class ComputeCollection<T>(Stream dataStream, ulong length, long offset) 
         return base.GetData<T>();
     }
 
-    public new IEnumerable<byte> GetDataRaw()
+    public new IAsyncEnumerable<byte[]> GetDataRaw()
     {
         return base.GetDataRaw();
     }

--- a/NFAI.Core/ComputeCollection.cs
+++ b/NFAI.Core/ComputeCollection.cs
@@ -36,7 +36,7 @@ public class ComputeCollection<T>(Stream dataStream, ulong length, long offset) 
         return base.GetData<T>();
     }
 
-    public new IAsyncEnumerable<byte[]> GetDataRaw()
+    public new IEnumerable<byte[]> GetDataRaw()
     {
         return base.GetDataRaw();
     }

--- a/NFAI.Models.Llama3/SamplingUtils.cs
+++ b/NFAI.Models.Llama3/SamplingUtils.cs
@@ -2,7 +2,7 @@ namespace NFAI.Models.Llama3;
 
 public static class SamplingUtils
 {
-    public static uint TopP(float[] values, float temperature = 0.6f, float topP = 0.9f, int topK = 40)
+    public static uint TopP(float[] values, float temperature = 0.5f, float topP = 0.95f, int topK = 40)
     {
         List<float> scaledLogits = values.Select(l => l / temperature).ToList();
         List<float> probs = Softmax(scaledLogits);

--- a/NFAI.Vulkan.Shaders/ShaderWrapper.cs
+++ b/NFAI.Vulkan.Shaders/ShaderWrapper.cs
@@ -68,8 +68,6 @@ public unsafe abstract class ShaderWrapper(Vk vk, Device device, VulkanBufferMan
         // 1) If the .spv file doesn’t exist, try to compile the .comp file using glslangValidator.
         if (!File.Exists(spvPath))
         {
-            Console.WriteLine($"[INFO] {spvPath} not found. Attempting to compile {compPath}...");
-
             if (!File.Exists(compPath))
             {
                 throw new FileNotFoundException($"Shader source .comp file not found: {compPath}");
@@ -97,11 +95,8 @@ public unsafe abstract class ShaderWrapper(Vk vk, Device device, VulkanBufferMan
             if (process.ExitCode != 0)
             {
                 string err = process.StandardOutput.ReadToEnd();
-                Console.WriteLine($"Failed to compile shader {compPath} -> {spvPath}.\nError:\n{err}");
                 throw new Exception($"Failed to compile shader {compPath} -> {spvPath}.");
             }
-
-            Console.WriteLine($"[INFO] Successfully compiled {compPath} -> {spvPath}");
         }
 
         // 2) Now read the compiled SPIR-V bytes from the .spv file

--- a/NFAI.Vulkan/VulkanBufferManager.cs
+++ b/NFAI.Vulkan/VulkanBufferManager.cs
@@ -130,13 +130,11 @@ public class VulkanBufferManager : IDisposable
     public void UploadData<T>(ref DeviceMemory memory, ComputeCollection<T> data) where T : struct
     {
         var queue = new ConcurrentQueue<byte[]>();
-        var t = Task.Run(async () =>
+        var t = Task.Run(() =>
         {
-            var enumerator = data.GetDataRaw().GetAsyncEnumerator();
-            // Read the data in batches
-            while (await enumerator.MoveNextAsync())
+            foreach (var item in data.GetDataRaw())
             {
-                queue.Enqueue(enumerator.Current);
+                queue.Enqueue(item);
             }
         });
         ulong dataSize = data.Length * (ulong)Unsafe.SizeOf<T>();

--- a/NFAI.Vulkan/VulkanBufferManager.cs
+++ b/NFAI.Vulkan/VulkanBufferManager.cs
@@ -1,5 +1,6 @@
 ﻿using NFAI.Core;
 using Silk.NET.Vulkan;
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using Buffer = Silk.NET.Vulkan.Buffer;
 
@@ -128,6 +129,16 @@ public class VulkanBufferManager : IDisposable
     /// </summary>
     public void UploadData<T>(ref DeviceMemory memory, ComputeCollection<T> data) where T : struct
     {
+        var queue = new ConcurrentQueue<byte[]>();
+        var t = Task.Run(async () =>
+        {
+            var enumerator = data.GetDataRaw().GetAsyncEnumerator();
+            // Read the data in batches
+            while (await enumerator.MoveNextAsync())
+            {
+                queue.Enqueue(enumerator.Current);
+            }
+        });
         ulong dataSize = data.Length * (ulong)Unsafe.SizeOf<T>();
         unsafe
         {
@@ -144,35 +155,37 @@ public class VulkanBufferManager : IDisposable
             {
                 // 2. Copy data as a batch rather than byte-by-byte
                 byte* dst = (byte*)mappedMemory;
-                ulong index = 0;
                 
                 // Create a temporary array to batch process data
-                T[] tempBuffer = new T[1024]; // Process in chunks
-                int count = 0;
-                
-                foreach (var item in data.GetData())
+                var sleepTime = 5;
+                while(!t.IsCompleted)
                 {
-                    tempBuffer[count++] = item;
-                    
-                    // When buffer is full or this is the last item, copy to GPU memory
-                    if (count == tempBuffer.Length || index + (ulong)count >= data.Length)
+                    if (queue.TryDequeue(out var batch))
                     {
-                        fixed (T* srcPtr = tempBuffer)
+                        // Copy the batch to the mapped memory
+                        fixed (byte* src = batch)
                         {
-                            ulong bytesToCopy = (ulong)count * (ulong)Unsafe.SizeOf<T>();
-                            System.Buffer.MemoryCopy(srcPtr, dst + index * (ulong)Unsafe.SizeOf<T>(), 
-                                                    bytesToCopy, bytesToCopy);
+                            Unsafe.CopyBlock(dst, src, (uint)batch.Length);
                         }
-                        
-                        index += (ulong)count;
-                        count = 0;
-                        
-                        if (index >= data.Length)
-                        {
-                            break;
-                        }
+                        dst += batch.Length;
+                    }
+                    else
+                    {
+                        // Sleep for a short time to avoid busy waiting
+                        Thread.Sleep(sleepTime);
+                        continue;
                     }
                 }
+
+                if (queue.TryDequeue(out var b))
+                {
+                    // Copy the batch to the mapped memory
+                    fixed (byte* src = b)
+                    {
+                        Unsafe.CopyBlock(dst, src, (uint)b.Length);
+                    }
+                }
+
             }
             finally
             {

--- a/NFAI/Program.cs
+++ b/NFAI/Program.cs
@@ -1,10 +1,13 @@
-﻿// parse the GGUF file
+﻿using System.Diagnostics;
 using Microsoft.Extensions.AI;
 using NFAI.GGUF;
 
 var path = Environment.GetEnvironmentVariable("GGUF_PATH") ?? throw new ArgumentNullException("GGUF_PATH", "GGUF_PATH environment variable is not set.");
 var parser = new Parser();
+var sw = Stopwatch.StartNew();
 var model = parser.Parse(path);
+sw.Stop();
+Console.WriteLine($"Loaded model in {sw.ElapsedMilliseconds}ms");
 Console.WriteLine("Enter 'quit' to quit: ");
 
 var input = string.Empty;


### PR DESCRIPTION
This pull request introduces several updates across multiple files to improve performance, add new functionality, and clean up the codebase. The most significant changes include optimizing data handling in `GetDataRaw`, modifying token sampling parameters, improving Vulkan buffer management with concurrent processing, and adding performance logging for model loading.

### Performance and Data Handling Improvements:
* [`NFAI.Core/AbstractComputeCollection.cs`](diffhunk://#diff-5797c277ddaf64e849e8b5ccb62d8a7df38678e3967f952c256a053e164dc996L36-R51): Changed `GetDataRaw` to return `IEnumerable<byte[]>` instead of `IEnumerable<byte>` for better batch processing. Adjusted the batch size to 100MB and added logic to handle `TypeSize` conversions, including a new method `HalfToSingle` for converting half-precision floats to single-precision. [[1]](diffhunk://#diff-5797c277ddaf64e849e8b5ccb62d8a7df38678e3967f952c256a053e164dc996L36-R51) [[2]](diffhunk://#diff-5797c277ddaf64e849e8b5ccb62d8a7df38678e3967f952c256a053e164dc996L68-R130)
* [`NFAI.Models.Llama3/SamplingUtils.cs`](diffhunk://#diff-0a81cb1e781f908941afde817c2d7cd90d4f0c620ecaef2519a4220525bcb11aL5-R5): Updated the `TopP` method to use a lower temperature (0.5) and a higher `topP` value (0.95) for improved token sampling.

### Vulkan Buffer Management Enhancements:
* [`NFAI.Vulkan/VulkanBufferManager.cs`](diffhunk://#diff-c0e1ce17d9dffb28014bd0bc1d9f1f377ff37a1f28b5485786af967f50e5442aR132-R139): Introduced a `ConcurrentQueue` and asynchronous processing in the `UploadData` method to enable concurrent data batching and uploading to GPU memory, reducing potential bottlenecks. [[1]](diffhunk://#diff-c0e1ce17d9dffb28014bd0bc1d9f1f377ff37a1f28b5485786af967f50e5442aR132-R139) [[2]](diffhunk://#diff-c0e1ce17d9dffb28014bd0bc1d9f1f377ff37a1f28b5485786af967f50e5442aL147-R186)

### Code Cleanup and Logging:
* [`NFAI/Program.cs`](diffhunk://#diff-79649252884ef2ead3589ba2c0ea3b03d65799fb713eb73c574a6f2a2790f17eL1-R10): Added performance logging to measure the time taken to load a model using a `Stopwatch`.
* [`NFAI.Vulkan.Shaders/ShaderWrapper.cs`](diffhunk://#diff-fec3ddd86a9c6bfb36cc93d121da84cad530f16dc60e69063910e037dd9170c6L71-L72): Removed unnecessary console logging during shader compilation for cleaner output. [[1]](diffhunk://#diff-fec3ddd86a9c6bfb36cc93d121da84cad530f16dc60e69063910e037dd9170c6L71-L72) [[2]](diffhunk://#diff-fec3ddd86a9c6bfb36cc93d121da84cad530f16dc60e69063910e037dd9170c6L100-L104)

### Minor Refactoring:
* [`NFAI.Models.Llama3/Model.cs`](diffhunk://#diff-43225829553056b47d248a9815c959477865e44a89911c74e0387b09a208c5d3L113-L114): Simplified token generation logic in `RunAsync` by removing unused variables and improving clarity in token handling. [[1]](diffhunk://#diff-43225829553056b47d248a9815c959477865e44a89911c74e0387b09a208c5d3L113-L114) [[2]](diffhunk://#diff-43225829553056b47d248a9815c959477865e44a89911c74e0387b09a208c5d3L136-R148) [[3]](diffhunk://#diff-43225829553056b47d248a9815c959477865e44a89911c74e0387b09a208c5d3L182-R181)